### PR TITLE
Refactor /users/ endpoint accessibility

### DIFF
--- a/course_rater_app/fixtures.py
+++ b/course_rater_app/fixtures.py
@@ -3,18 +3,21 @@ import json
 
 users = [
     {
+        "id": 1,
         "username": "user1",
         "email": "user1@example.com",
         "password": "password1",
         "year": "B1"
     },
     {
+        "id": 2,
         "username": "user2",
         "email": "user2@example.com",
         "password": "password2",
         "year": "B2"
     },
     {
+        "id": 3,
         "username": "admin",
         "email": "admin@example.com",
         "password": "password",
@@ -98,11 +101,13 @@ courses = [
 
 labs = [
     {
+        "id": 1,
         "professor": "Professor 1",
         "topic": "Topic 1",
         "website": "https://topic1.example.com",
     },
     {
+        "id": 2,
         "professor": "Professor 2",
         "topic": "Topic 2",
         "website": "https://topic2.example.com",

--- a/course_rater_app/permissions.py
+++ b/course_rater_app/permissions.py
@@ -16,6 +16,15 @@ class IsReviewerOrAdminOrReadOnly(permissions.BasePermission):
             return obj.reviewer == request.user or request.user.is_staff
 
 
+class IsAdmin(permissions.BasePermission):
+    """Allow Admin to perform all methods.
+
+    Used to prevent any non-admin from interacting with an endpoint.
+    """
+    def has_permission(self, request, view):
+        return request.user.is_staff
+
+
 class IsAdminOrReadOnly(permissions.BasePermission):
     """Allow Admin to read/update/delete.
 

--- a/course_rater_app/views.py
+++ b/course_rater_app/views.py
@@ -3,7 +3,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from course_rater_app.models import Course, CourseReview, Lab, LabReview, User
-from course_rater_app.permissions import IsAdminOrReadOnly
+from course_rater_app.permissions import IsAdmin, IsAdminOrReadOnly
 from course_rater_app.serializers import (CourseSerializer,
                                           CourseReviewSerializer,
                                           LabSerializer,
@@ -17,7 +17,6 @@ from course_rater_app.serializers import (CourseSerializer,
 def api_index(request, format=None):
     """Handle requests to index page."""
     return Response({
-        'users': reverse('user-list', request=request, format=format),
         'labs': reverse('lab-list', request=request, format=format),
         'courses': reverse('course-list', request=request, format=format),
     })
@@ -103,13 +102,13 @@ class UserList(generics.ListCreateAPIView):
     """Handle requests to 'users/'."""
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [IsAdmin]
 
 
 class UserDetail(generics.RetrieveUpdateDestroyAPIView):
     """Handle requests to 'users/<int:pk>/'."""
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [IsAdminOrReadOnly]
+    permission_classes = [IsAdmin]
     lookup_field = 'username'
 


### PR DESCRIPTION
# About
Prevent non-admin from interacting with the `/users/` endpoint for the sake of privacy.
May eventually rollback this change and instead and change the response format.