### PR TITLE
Update config for WSGIPassAuthorization

### DIFF
--- a/.ebextensions/container.config
+++ b/.ebextensions/container.config
@@ -1,0 +1,6 @@
+container_commands:
+  01_migrate:
+    command: "django-admin.py migrate"
+    leader_only: true
+  02_wsgipass:
+    command: 'echo "WSGIPassAuthorization On" >> ../wsgi.conf'

--- a/.ebextensions/db-migrate.config
+++ b/.ebextensions/db-migrate.config
@@ -1,8 +1,0 @@
-container_commands:
-  01_migrate:
-    command: "django-admin.py migrate"
-    leader_only: true
-option_settings:
-  aws:elasticbeanstalk:application:environment:
-    DJANGO_SETTINGS_MODULE: course_rater.settings
-

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -1,4 +1,5 @@
 option_settings:
+  aws:elasticbeanstalk:application:environment:
+    DJANGO_SETTINGS_MODULE: course_rater.settings
   aws:elasticbeanstalk:container:python:
     WSGIPath: course_rater/wsgi.py
-


### PR DESCRIPTION
# Problem
`WSGIPassAuthorization` needs to be set to true for Apache reverse proxy server in order for Django to receive posted credentials. This has been done manually with SSH until now. AWS periodically resets the server settings so this wipes any configuration that is done.

# Solution
Add config to automatically set `WSGIPassAuthorization` to true.